### PR TITLE
[feat] speedup legal_move()

### DIFF
--- a/simple_board.py
+++ b/simple_board.py
@@ -26,15 +26,38 @@ class SimpleGoBoard(object):
         """
         Check whether it is legal for color to play on point
         """
-        board_copy = self.copy()
-        # Try to play the move on a temporary copy of board
-        # This prevents the board from being messed up by the move
-        try:
-            legal = board_copy.play_move(point, color)
-        except:
+        assert is_black_white(color)
+        # Special cases
+        if point == PASS:
+            return False
+        elif self.board[point] != EMPTY:
+            return False
+        if point == self.ko_recapture:
             return False
             
-        return legal
+        # General case: deal with captures, suicide, and next ko point
+        opp_color = GoBoardUtil.opponent(color)
+        in_enemy_eye = self._is_surrounded(point, opp_color)
+        self.board[point] = color
+        single_captures = []
+        neighbors = self.neighbors[point]
+        for nb in neighbors:
+            if self.board[nb] == opp_color:
+                single_capture = self._detect_and_process_capture(nb)
+                if single_capture == True:
+                    self.board[point] = EMPTY
+                    return False
+        if not self._stone_has_liberty(point):
+            # check suicide of whole block
+            block = self._block_of(point)
+            if not self._has_liberty(block): # undo suicide move
+                self.board[point] = EMPTY
+                return False
+        self.ko_recapture = None
+        if in_enemy_eye and len(single_captures) == 1:
+            self.ko_recapture = single_captures[0]
+        self.board[point] = EMPTY
+        return True
 
     def _detect_captures(self, point, opp_color):
         """


### PR DESCRIPTION
do not copy board, try to play move, and then undo move. instead, perform legal checks on the same board instance and undo before returning from legal_move(). 

the speedup for solve is about 3x. 